### PR TITLE
fix: alternative line number message

### DIFF
--- a/src/dragonfly/_notify.py
+++ b/src/dragonfly/_notify.py
@@ -92,9 +92,9 @@ def dfly(message: str) -> None:
 def frame(frame: FrameType) -> None:
     code = frame.f_code
     log.info(
-        "File %s, line %d, in %s",
+        "File %s, line %s, in %s",
         code.co_filename,
-        frame.f_lineno or f"<unknown> (lasti {frame.f_lasti})",
+        frame.f_lineno and str(frame.f_lineno) or f"<unknown> (lasti {frame.f_lasti})",
         code.co_name,
     )
 


### PR DESCRIPTION
We fix the format string for logs that expect line numbers from frames. Since these can be set to `None`, and we use a custom string in this case, we ensure that the format string uses a string placeholder to avoid formatting error caused by the format string expecting a number instead.